### PR TITLE
ci: bump golangci-lint to v1.54

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,6 @@ jobs:
           cache-dependency-path: go.sum
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48
+          version: v1.54
           skip-cache: true
           args: --timeout 10m --verbose

--- a/internal/adapters/lambda/adapt_test.go
+++ b/internal/adapters/lambda/adapt_test.go
@@ -124,14 +124,15 @@ func bootstrapFunction(t *testing.T, ra *adapters.RootAdapter, spec functionDeta
 	require.NoError(t, err)
 
 	for i, permission := range spec.permissions {
+		perm := permission
 		statementID := fmt.Sprintf("%d", i)
 		_, err = api.AddPermission(ra.Context(), &lambdaapi.AddPermissionInput{
-			Action:       &permission.action,
+			Action:       &perm.action,
 			FunctionName: &spec.name,
 			Qualifier:    output.Version,
-			Principal:    &permission.principal,
+			Principal:    &perm.principal,
 			StatementId:  &statementID,
-			SourceArn:    &permission.source,
+			SourceArn:    &perm.source,
 		})
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
In v1.51 added support for Go 1.20.