### PR TITLE
remove usage of old aws-sdk-go (v1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 require (
 	github.com/aquasecurity/go-mock-aws v0.0.0-20240109054747-49e4b5da33cb
 	github.com/aquasecurity/trivy v0.49.2-0.20240216090457-32a02a95dd06
-	github.com/aws/aws-sdk-go v1.49.21
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/config v1.26.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.16

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go v1.49.21 h1:Rl8KW6HqkwzhATwvXhyr7vD4JFUMi7oXGAw9SrxxIFY=
-github.com/aws/aws-sdk-go v1.49.21/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.24.1 h1:xAojnj+ktS95YZlDf0zxWBkbFtymPeDP+rvUQIH3uAU=
 github.com/aws/aws-sdk-go-v2 v1.24.1/go.mod h1:LNh45Br1YAkEKaAqvmE1m8FUx6a5b/V0oAKV7of29b4=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 h1:OCs21ST2LrepDfD3lwlQiOqIGp6JiEUqG84GzTDoyJs=


### PR DESCRIPTION
This PR removes the last usage of "github.com/aws/aws-sdk-go" in this repo. [Deprecation notice](https://aws.amazon.com/fr/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/)

The checked interface is from the old sdk while the call is from the v2, looking at the code:
- https://github.com/aws/aws-sdk-go-v2/blob/7cb105f17b3a12d4b69219ce9957d517dba299d8/service/s3/api_op_GetPublicAccessBlock.go#L33
- https://github.com/aws/aws-sdk-go-v2/blob/7cb105f17b3a12d4b69219ce9957d517dba299d8/service/s3/api_client.go#L131

We replace the sdk v1 error definition by our own simplified interface.

Motivation: the end-goal here is to reduce, and then fully remove this dependency from trivy itself.