### PR TITLE
ci: pin Go version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  GO_VERSION: '1.22'
+
 jobs:
   golangci:
     name: lint
@@ -22,9 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: go.sum
+          go-version: ${{ env.GO_VERSION }}
+
       - uses: golangci/golangci-lint-action@v5
         with:
           version: v1.54

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - "v*"
 
+env:
+  GO_VERSION: '1.22'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Go 1.22
-        uses: actions/setup-go@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Build
         run: make build

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -21,8 +21,15 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-go@v5
+      if: matrix.os != 'windows-latest'
       with:
         go-version: ${{ env.GO_VERSION }}
+
+    - uses: actions/setup-go@v5
+      if: matrix.os == 'windows-latest'
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: false
 
     - name: go mod tidy
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -6,6 +6,9 @@ on:
   schedule:
   - cron:  0 23 * * *
 
+env:
+  GO_VERSION: '1.22'
+
 jobs:
   build:
     name: building defsec
@@ -18,17 +21,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-go@v5
-      if: matrix.os != 'windows-latest'
       with:
-        go-version-file: go.mod
-        cache: true
-        cache-dependency-path: go.sum
-    
-    - uses: actions/setup-go@v5
-      if: matrix.os == 'windows-latest'
-      with:
-        go-version-file: go.mod
-        cache: false
+        go-version: ${{ env.GO_VERSION }}
 
     - name: go mod tidy
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
This PR fixes the issue with the Go cache https://github.com/aquasecurity/trivy-aws/actions/runs/10381795510/job/28743812158?pr=209

### Before
```bash
Successfully set up Go version 1.22.0
go: downloading go1.22.2 (linux/amd64)
/opt/hostedtoolcache/go/1.22.0/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.22.0/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Received 255852544 of 1175999812 ([21](https://github.com/aquasecurity/trivy-aws/actions/runs/10381795510/job/28743812158?pr=209#step:3:22).8%), 244.0 MBs/sec
Received 524288000 of 1175999812 (44.6%), 250.0 MBs/sec
Received 788529152 of 1175999812 (67.1%), 250.3 MBs/sec
Received 1040187392 of 1175999812 (88.5%), 247.8 MBs/sec
Cache Size: ~11[22](https://github.com/aquasecurity/trivy-aws/actions/runs/10381795510/job/28743812158?pr=209#step:3:23) MB (1175999812 B)
/usr/bin/tar -xf /home/runner/work/_temp/9c71bdc4-df57-4f93-a1f7-be1ee071db2b/cache.tzst -P -C /home/runner/work/trivy-aws/trivy-aws --use-compress-program unzstd
Received 1175999812 of 1175999812 (100.0%), 2[24](https://github.com/aquasecurity/trivy-aws/actions/runs/10381795510/job/28743812158?pr=209#step:3:25).1 MBs/sec
/usr/bin/tar: ../../../go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.2.linux-amd64/lib/time/update.bash: Cannot open: File exists
/usr/bin/tar: ../../../go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.2.linux-amd64/lib/time/README: Cannot open: File exists
/usr/bin/tar: ../../../go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.2.linux-amd64/lib/time/mkzip.go: Cannot open: File exists
...
/usr/bin/tar: Exiting with failure status due to previous errors
Warning: Failed to restore: "/usr/bin/tar" failed with error: The process '/usr/bin/tar' failed with exit code 2
Cache is not found
```

### After
```
Successfully set up Go version 1.22
/opt/hostedtoolcache/go/1.22.5/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.22.5/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Received [13](https://github.com/aquasecurity/trivy-aws/actions/runs/10382449293/job/28745550572?pr=210#step:3:14)0023424 of 1041205102 (12.5%), 124.0 MBs/sec
Received 32296[14](https://github.com/aquasecurity/trivy-aws/actions/runs/10382449293/job/28745550572?pr=210#step:3:15)08 of 1041205102 (31.0%), 154.0 MBs/sec
Received 507510784 of 1041205102 (48.7%), 161.3 MBs/sec
Received 68367[15](https://github.com/aquasecurity/trivy-aws/actions/runs/10382449293/job/28745550572?pr=210#step:3:16)52 of 1041205102 (65.7%), [16](https://github.com/aquasecurity/trivy-aws/actions/runs/10382449293/job/28745550572?pr=210#step:3:17)3.0 MBs/sec
Received 851443712 of 1041205102 (81.8%), 162.4 MBs/sec
Received 1024427886 of 1041205102 (98.4%), 162.8 MBs/sec
Cache Size: ~993 MB (1041205102 B)
/usr/bin/tar -xf /home/runner/work/_temp/6fc419ec-8336-4f65-bec2-a0c42c38[18](https://github.com/aquasecurity/trivy-aws/actions/runs/10382449293/job/28745550572?pr=210#step:3:19)e9/cache.tzst -P -C /home/runner/work/trivy-aws/trivy-aws --use-compress-program unzstd
Received 1041205102 of 1041205102 (100.0%), 141.8 MBs/sec
Cache restored successfully
Cache restored from key: setup-go-Linux-ubuntu22-go-1.22.5-223a8fa6983d09b6092ef1d59e066159c5e09a12fd679c1389a128fb9[19](https://github.com/aquasecurity/trivy-aws/actions/runs/10382449293/job/28745550572?pr=210#step:3:20)d8198
```