### PR TITLE
Report: use 'summary' for summary table, 'all' for detailed report

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -117,12 +117,15 @@ func Write(ctx context.Context, rep *Report, opt flag.Options, fromCache bool) e
 			if err := writeResultsForARN(rep, filtered, output, opt.Services[0], opt.ARN, opt.Severities); err != nil {
 				return err
 			}
-		default:
+		case opt.ReportFormat == "summary":
 			if err := writeServiceTable(rep, filtered, output); err != nil {
 				return err
 			}
+		
+		default:
+			return pkgReport.Write(ctx, base, opt)
 		}
-
+		
 		// render cache info
 		if fromCache {
 			_ = tml.Fprintf(output, "\n<blue>This scan report was loaded from cached results. If you'd like to run a fresh scan, use --update-cache.</blue>\n")

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -121,7 +121,6 @@ func Write(ctx context.Context, rep *Report, opt flag.Options, fromCache bool) e
 			if err := writeServiceTable(rep, filtered, output); err != nil {
 				return err
 			}
-		
 		default:
 			return pkgReport.Write(ctx, base, opt)
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -124,7 +124,7 @@ func Write(ctx context.Context, rep *Report, opt flag.Options, fromCache bool) e
 		default:
 			return pkgReport.Write(ctx, base, opt)
 		}
-		
+
 		// render cache info
 		if fromCache {
 			_ = tml.Fprintf(output, "\n<blue>This scan report was loaded from cached results. If you'd like to run a fresh scan, use --update-cache.</blue>\n")


### PR DESCRIPTION
A Trivy AWS user might want to get a detailed report for all resources within an account. The current report capabilities only allow for a 'summary' report, which lists all services and severity count/

This PR allow users to select between summary and detailed by port by using the --report flag (either 'summary' or 'all').