### PR TITLE
bump manifest to v0.14.2

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,7 +2,7 @@ name: aws
 repository: github.com/aquasecurity/trivy-aws
 maintainer: aquasecurity
 summary: Trivy AWS Cloud scanning plugin
-version: "0.14.1"
+version: "0.14.2"
 usage: AWS Trivy plugin
 description: |-
   Trivy AWS plugin for the Trivy security scanner
@@ -11,25 +11,25 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.1/trivy-aws-darwin-amd64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.2/trivy-aws-darwin-amd64.tar.gz
     bin: ./trivy-aws-darwin-amd64
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.1/trivy-aws-darwin-arm64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.2/trivy-aws-darwin-arm64.tar.gz
     bin: ./trivy-aws-darwin-arm64
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.1/trivy-aws-linux-amd64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.2/trivy-aws-linux-amd64.tar.gz
     bin: ./trivy-aws-linux-amd64
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.1/trivy-aws-linux-arm64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.2/trivy-aws-linux-arm64.tar.gz
     bin: ./trivy-aws-linux-arm64
   - selector:
       os: windows
       arch: amd64
-    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.1/trivy-aws-windows-amd64.tar.gz
+    uri: https://github.com/aquasecurity/trivy-aws/releases/download/v0.14.2/trivy-aws-windows-amd64.tar.gz
     bin: ./trivy-aws-windows-amd64


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/trivy-aws/issues/254