### PR TITLE
ci: check if manifest updated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,22 @@ on:
       - "v*"
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set new version from tag
+        run: echo "NEW_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Check if manifest is updated
+        run: |
+          make bump-manifest
+          if [ -n "$(git status --porcelain plugin.yaml)" ]; then
+            echo "The version of the plugin in manifest is not updated. Please run 'NEW_VERSION=version make bump-manifest'"
+            exit 1
+          fi
 
       - name: Set up Go 1.22
         uses: actions/setup-go@v4

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SED=$(shell command -v gsed || command -v sed)
+
 .PHONY: test
 test:
 	go test -race ./...
@@ -35,3 +37,11 @@ update-aws-deps:
 .PHONY: clean
 clean:
 	rm -rf trivy-aws*
+
+.PHONY: bump-manifest
+bump-manifest:
+	@[ $$NEW_VERSION ] || ( echo "env 'NEW_VERSION' is not set"; exit 1 )
+	@current_version=$$(cat plugin.yaml | grep 'version' | awk '{ print $$2}' | tr -d '"') ;\
+	echo Current version: $$current_version ;\
+	echo New version: $$NEW_VERSION ;\
+	$(SED) -i -e "s/$$current_version/$$NEW_VERSION/g" plugin.yaml ;\


### PR DESCRIPTION
This PR adds a check that the plugin version is updated in the manifest before release. This will avoid issues such as: https://github.com/aquasecurity/trivy-aws/issues/254

Failed run without an updated manifest: https://github.com/nikpivkin/trivy-aws/actions/runs/11853656463/job/33034215717
Successful run: https://github.com/nikpivkin/trivy-aws/actions/runs/11853732652/job/33034441242