### PR TITLE
refactor: remove list of services from --help output

### DIFF
--- a/pkg/commands/app.go
+++ b/pkg/commands/app.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -55,12 +54,8 @@ func NewCmd() *cobra.Command {
 		Aliases: []string{},
 		Args:    cobra.ExactArgs(0),
 		Short:   "[EXPERIMENTAL] Scan AWS account",
-		Long: fmt.Sprintf(`Scan an AWS account for misconfigurations. It uses the same authentication methods as the AWS CLI. See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html
-
-The following services are supported:
-
-- %s
-`, strings.Join(services, "\n- ")),
+		Long: fmt.Sprintf(`
+  Scan an AWS account for misconfigurations. It uses the same authentication methods as the AWS CLI.`),
 		Example: `  # basic scanning
   $ trivy aws --region us-east-1
 


### PR DESCRIPTION
removes listing supported AWS services when running `trivy aws --help`

Relates to #327

As a new user of trivy and this plugin, I do not find this list helpful in the `--help` output.
Help output should be for explaining required, recommended, and optional flags/arguments/parameters.
The README provides a list of supported services, which should be sufficient.